### PR TITLE
revert back price type to number

### DIFF
--- a/src/crawler/crawler.ebay.ts
+++ b/src/crawler/crawler.ebay.ts
@@ -252,7 +252,7 @@ export class EbayCrawler implements IBaseCrawler {
 		return {
 			id: nanoid(),
 			title: raw.title,
-			price: this.parsePrice(raw.price)?.toLocaleString(),
+			price: this.parsePrice(raw.price),
 			currency: "USD",
 			imageUrl: raw.imageUrl !== "N/A" ? raw.imageUrl : undefined,
 			productUrl:

--- a/src/crawler/crawler.walmart.ts
+++ b/src/crawler/crawler.walmart.ts
@@ -289,7 +289,7 @@ export class WalmartCrawler implements IBaseCrawler {
 		return {
 			id: nanoid(),
 			title: raw.title,
-			price: this.parsePrice(raw.price)?.toString(),
+			price: this.parsePrice(raw.price),
 			currency: "USD",
 			imageUrl: raw.imageUrl !== "N/A" ? raw.imageUrl : undefined,
 			productUrl:

--- a/src/crawler/types/crawler.types.ts
+++ b/src/crawler/types/crawler.types.ts
@@ -3,7 +3,7 @@
 export interface CrawledProduct {
 	id: string; // ← NEW: Unique identifier
 	title: string;
-	price?: string;
+	price?: number;
 	currency?: string;
 	imageUrl?: string;
 	productUrl?: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Product price values across all crawlers are now returned as numbers instead of string representations for improved data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->